### PR TITLE
Change image path retrieval process

### DIFF
--- a/camml/megadetector_json_to_csv.py
+++ b/camml/megadetector_json_to_csv.py
@@ -15,7 +15,6 @@
 
 import json
 import csv
-import os
 import argparse
 import random
 
@@ -34,8 +33,6 @@ def main():
                         help="filepath for the JSON input file")
     parser.add_argument("output_file", type=str,
                         help="filepath for the CSV output file")
-    parser.add_argument("image_folder_path", type=str,
-                        help="path to the image folder")
     parser.add_argument("conf", type=float,
                         help="confidence threshold")
     parser.add_argument("--include",
@@ -57,8 +54,7 @@ def main():
 
         for img in image_data:
             # Set the file path
-            image_path = os.path.join(args.image_folder_path,
-                                      img['file'])
+            image_path = img['file']
 
             if 'failure' in img.keys():
                 print(img['file'] + ' failed to access.\n')
@@ -94,8 +90,9 @@ def main():
                         set_type = 'TEST'
 
                     # Get the class name from the image file name
-                    slash = img['file'].find('/')
-                    category = img['file'][0:slash]
+                    slash = img['file'].rfind('/')
+                    prev_slash = img['file'][0:slash - 1].rfind('/')
+                    category = img['file'][prev_slash + 1:slash]
 
                     # Megadetector uses 3 categories 1-animal, 2-person,
                     # 3-vehicle, only the animal detections are needed

--- a/camml/megadetector_json_to_csv.py
+++ b/camml/megadetector_json_to_csv.py
@@ -90,9 +90,7 @@ def main():
                         set_type = 'TEST'
 
                     # Get the class name from the image file name
-                    slash = img['file'].rfind('/')
-                    prev_slash = img['file'][0:slash - 1].rfind('/')
-                    category = img['file'][prev_slash + 1:slash]
+                    category = img['file'].strip('/').split('/')[-2]
 
                     # Megadetector uses 3 categories 1-animal, 2-person,
                     # 3-vehicle, only the animal detections are needed


### PR DESCRIPTION
Removes `image_folder_path` argument and takes the full image path from the MegaDetector output `.json` file instead. This changes the way we run `run_detector_batch.py` by omitting the `--output_relative_filenames` argument to get the full path to each image instead of the relative path. This change will also be reflected in the `README.md` training instructions. This change resolves issue #13.